### PR TITLE
Add dependency setup script for Codex

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Setup script to install dependencies for the Codex environment.
+# Run using: bash .codex/setup.sh
+
+set -euo pipefail
+
+echo "Installing Node.js dependencies..."
+npm ci
+
+echo "Installing Firebase CLI globally..."
+npm install -g firebase-tools
+
+echo "Setup complete"
+


### PR DESCRIPTION
## Summary
- enhance `.codex/setup.sh` to install dependencies and firebase CLI

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: cannot find several type definitions)*
